### PR TITLE
chore: set GITHUB_TOKEN everywhere in actions

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -10,6 +10,7 @@ jobs:
     runs-on: macos-latest
     env:
       GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     steps:
       - uses: actions/checkout@v3
 
@@ -40,6 +41,7 @@ jobs:
       - name: Kick off publish workflow
         if: startsWith(github.event.pull_request.title, 'release:')
         env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           FORMULA=$(echo '${{ github.event.pull_request.title }}' | awk -F ' ' '{print $2}')


### PR DESCRIPTION
The `tests.yml` can be kinda finicky at the moment, sometimes erroring out with an error message like this:
```
  FORMULA=$(echo 'release: knock 0.1.4' | awk -F ' ' '{print $2}')
  VERSION=$(echo 'release: knock 0.1.4' | awk -F ' ' '{print $3}')
  gh workflow run publish.yml -f branch=update-knock.rb-1689094851 -f formula=${FORMULA} -f version=${VERSION}
  shell: /bin/bash -e {0}
  env:
    GH_TOKEN: ***
    HOMEBREW_NO_INSTALL_FROM_API: 
    GITHUB_TOKEN: ***
/Users/runner/work/_temp/0366e690-0dca-4587-bc2f-3ed38b3d8515.sh: line 3: gh: command not found
Error: Process completed with exit code 127.
```

It's complaining that the Github CLI command `gh` is not found, even though `GITHUB_TOKEN` env var is available - which is pretty perplexing and annoying because according to [their doc](https://docs.github.com/en/actions/using-workflows/using-github-cli-in-workflows), `gh` should be automatically installed when `GITHUB_TOKEN` env var is set. 

Here I'm adding both `GH_TOKEN` and `GITHUB_TOKEN` env vars at both the job level and the step level with the hopes of making it less finicky, but we might need to take another look if it continues to be finicky.