### PR TITLE
fix: run tests on ubuntu latest

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -6,7 +6,7 @@ on:
 jobs:
   # Runs a series of brew tests on new pull requests.
   run-tests:
-    runs-on: macos-latest
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
 


### PR DESCRIPTION
This fixes the following brew audit error we saw in the tests action [here](https://github.com/knocklabs/homebrew-tap/actions/runs/8887078564/job/24401723807): 

>   knocklabs/tap/knock
    * Binaries built for a non-native architecture were installed into knock's prefix.
      The offending files are:
        /opt/homebrew/Cellar/knock/0.1.12/libexec/bin/node	(x86_64)
  Error: 1 problem in 1 formula detected.
  Error: Binaries built for a non-native architecture were installed into knock's prefix.
  The offending files are:
    /opt/homebrew/Cellar/knock/0.1.12/libexec/bin/node	(x86_64)

I originally set up that action to run on `macos-latest` since the homebrew distribution is meant for macos, but given that we build the CLI release itself on [ubuntu-latest](https://github.com/knocklabs/knock-cli/blob/main/.github/workflows/on-release-created.yml#L7) ([targeting darwin-x64](https://github.com/knocklabs/knock-cli/blob/main/.github/workflows/on-release-created.yml#L7)), it probably makes sense to also run this test action on ubuntu-latest as well. It seems like there have been recent changes with `macos-latest` that now does not expect the x86_64 architecture. 