### PR TITLE
fix: brew test-bot --only-tap-syntax errors

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -24,7 +24,7 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Fetch release branch
-        run: git fetch origin ${BRANCH}:release --depth 1
+        run: git fetch origin "${BRANCH}:release" --depth 1
 
       # This step is based on how Twilio's release script handles versioning:
       # https://github.com/twilio/homebrew-brew/blob/main/.github/scripts/update-formula.sh
@@ -33,16 +33,16 @@ jobs:
           # Copy the current version of the formula to another formula suffixed
           # with the version number, to support installing different versions.
           # For example: Formula/foo.rb -> Formula/foo@0.0.12.rb
-          CURR_URL=$(git show main:Formula/${FORMULA}.rb | awk '/^ *url/ {print $2}')
-          CURR_VER=$(echo $CURR_URL | awk 'match($0, /v([0-9]+\.[0-9]+\.[0-9]+)/, m) { print m[1] }')
-          cp --f ./Formula/${FORMULA}.rb ./Formula/${FORMULA}@${CURR_VER}.rb
+          CURR_URL=$(git show "main:Formula/${FORMULA}.rb" | awk '/^ *url/ {print $2}')
+          CURR_VER=$(echo "$CURR_URL" | awk 'match($0, /v([0-9]+\.[0-9]+\.[0-9]+)/, m) { print m[1] }')
+          cp --f "./Formula/${FORMULA}.rb" "./Formula/${FORMULA}@${CURR_VER}.rb"
           # It seems homebrew expects a class name for each formula to be
           # consistent with its file name, so also update the class name.
-          CLASSNAME=$(echo $FORMULA | sed -e "s/\b./\u&/g")AT$(echo $CURR_VER | tr -dc '[:alnum:]\n\r' | sed 's/[[:alpha:]]/\U&/')
-          sed -i.bak "s/^class [^ ]*/class $CLASSNAME/" Formula/$FORMULA@$CURR_VER.rb
+          CLASSNAME=${FORMULA^}AT${CURR_VER//[^[:alnum:]]/}
+          sed -i.bak "s/^class [^ ]*/class $CLASSNAME/" "Formula/${FORMULA}@${CURR_VER}.rb"
 
       - name: Get the new version from release branch
-        run: git restore --source release Formula/${FORMULA}.rb
+        run: git restore --source release "Formula/${FORMULA}.rb"
 
       - name: Copy over the Aliases directory from release branch
         run: git restore --source release Aliases/
@@ -64,4 +64,4 @@ jobs:
 
       # Close the pull request.
       - name: Delete release branch
-        run: git push --delete origin $BRANCH
+        run: git push --delete origin "$BRANCH"

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -43,9 +43,11 @@ jobs:
 
       - name: Kick off publish workflow
         if: startsWith(github.event.pull_request.title, 'release:')
-        run: |
-          FORMULA=$(echo '${{ github.event.pull_request.title }}' | awk -F ' ' '{print $2}')
-          VERSION=$(echo '${{ github.event.pull_request.title }}' | awk -F ' ' '{print $3}')
-          gh workflow run publish.yml -f branch=${{ github.event.pull_request.head.ref }} -f formula=${FORMULA} -f version=${VERSION}
         env:
+          PR_TITLE: ${{ github.event.pull_request.title }}
+          PR_HEAD_REF: ${{ github.event.pull_request.head.ref }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          FORMULA=$(echo "$PR_TITLE" | awk -F ' ' '{print $2}')
+          VERSION=$(echo "$PR_TITLE" | awk -F ' ' '{print $3}')
+          gh workflow run publish.yml -f branch="$PR_HEAD_REF" -f formula="${FORMULA}" -f version="${VERSION}"


### PR DESCRIPTION
Fixes the errors flagged here: https://github.com/knocklabs/homebrew-tap/actions/runs/15589663648/job/43905427817.

As part of the `brew test-bot --only-tap-syntax` step, it runs various linters over this repo. It's a bit prickly and can be annoying, but on net I found it still helpful to keep things up-to-date so I've kept it around.