### PR TITLE
fix ci: set env var HOMEBREW_NO_SANDBOX_LINUX=1

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -7,6 +7,11 @@ jobs:
   # Runs a series of brew tests on new pull requests.
   run-tests:
     runs-on: ubuntu-latest
+    env:
+      # The Linux sandbox requires a rootless `bwrap` (Bubblewrap), which isn't
+      # usable on the ubuntu-latest runner (Ubuntu 24.04 restricts unprivileged
+      # user namespaces). Disable it so `brew doctor` / test-bot don't fail.
+      HOMEBREW_NO_SANDBOX_LINUX: 1
     steps:
       - uses: actions/checkout@v4
 


### PR DESCRIPTION
Fixes a new error we are seeing in the run-tests action: https://github.com/knocklabs/homebrew-tap/actions/runs/27028983563/job/79784681545

`brew test-bot --only-setup` runs brew doctor, and recent Homebrew versions added a hard doctor check: the Linux sandbox (HOMEBREW_SANDBOX_LINUX, which is now set by default) requires a rootless bwrap (Bubblewrap) executable on PATH. 

On the ubuntu-latest (24.04/noble) runner, bwrap either isn't installed or can't run rootless (Ubuntu 24.04's AppArmor restricts unprivileged user namespaces) so the check fails and the step exits 1. Homebrew prints the fix itself in that output:
```
As a final workaround, disable the Linux sandbox:  export HOMEBREW_NO_SANDBOX_LINUX=1
```